### PR TITLE
fix emitting of more windows than requested

### DIFF
--- a/src/test/java/hu/akarnokd/rxjava2/operators/FlowableBufferPredicateTest.java
+++ b/src/test/java/hu/akarnokd/rxjava2/operators/FlowableBufferPredicateTest.java
@@ -98,6 +98,23 @@ public class FlowableBufferPredicateTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    public void whileMatchBegin() {
+        Flowable.just(-1, 1, 2)
+        .compose(FlowableTransformers.bufferWhile(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v != -1;
+            }
+        }))
+        .test()
+        .assertResult(
+                Arrays.<Integer>asList(),
+                Arrays.asList(-1, 1, 2)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     public void untilNormal() {
         Flowable.just(1, 2, -1, 3, 4, 5, -1, -1, 6)
         .compose(FlowableTransformers.bufferUntil(new Predicate<Integer>() {
@@ -158,6 +175,23 @@ public class FlowableBufferPredicateTest {
                 Arrays.asList(3, 4, 5, -1),
                 Arrays.asList(-1),
                 Arrays.asList(6)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void untilMatchBegin() {
+        Flowable.just(-1, 1, 2)
+        .compose(FlowableTransformers.bufferUntil(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v == -1;
+            }
+        }))
+        .test()
+        .assertResult(
+                Arrays.asList(-1),
+                Arrays.asList(1, 2)
         );
     }
 
@@ -448,4 +482,20 @@ public class FlowableBufferPredicateTest {
         );
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void splitMatchBegin() {
+        Flowable.just(-1, 1, 2)
+        .compose(FlowableTransformers.bufferSplit(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v == -1;
+            }
+        }))
+        .test()
+        .assertResult(
+                Arrays.<Integer>asList(),
+                Arrays.asList(1, 2)
+        );
+    }
 }

--- a/src/test/java/hu/akarnokd/rxjava2/operators/FlowableWindowPredicateTest.java
+++ b/src/test/java/hu/akarnokd/rxjava2/operators/FlowableWindowPredicateTest.java
@@ -19,6 +19,7 @@ package hu.akarnokd.rxjava2.operators;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.reactivestreams.Subscriber;
@@ -472,5 +473,24 @@ public class FlowableWindowPredicateTest {
                 Arrays.<Integer>asList(),
                 Arrays.asList(6)
         );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void whileDrainQueue() {
+        // test that window is emitted right away, not when next value arrives
+        Flowable.concat(Flowable.just(1L, 2L, -1L), Flowable.timer(1, TimeUnit.SECONDS))
+        .compose(FlowableTransformers.windowWhile(new Predicate<Long>() {
+            @Override
+            public boolean test(Long v) throws Exception {
+                return v != -1L;
+            }
+        }))
+        .test(0)
+        .assertNoValues()
+        .requestMore(1)
+        .assertValueCount(1)
+        .requestMore(1)
+        .assertValueCount(2);
     }
 }

--- a/src/test/java/hu/akarnokd/rxjava2/operators/FlowableWindowPredicateTest.java
+++ b/src/test/java/hu/akarnokd/rxjava2/operators/FlowableWindowPredicateTest.java
@@ -135,6 +135,24 @@ public class FlowableWindowPredicateTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    public void whileMatchBegin() {
+        Flowable.just(-1, 1, 2)
+        .compose(FlowableTransformers.windowWhile(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v != -1;
+            }
+        }))
+        .flatMapSingle(toList)
+        .test()
+        .assertResult(
+                Arrays.<Integer>asList(),
+                Arrays.asList(-1, 1, 2)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     public void untilNormal() {
         Flowable.just(1, 2, -1, 3, 4, 5, -1, -1, 6)
         .compose(FlowableTransformers.windowUntil(new Predicate<Integer>() {
@@ -219,6 +237,25 @@ public class FlowableWindowPredicateTest {
         .assertValueCount(3)
         .requestMore(1)
         .assertValueCount(4);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void untilMatchBegin() {
+        Flowable.just(-1, 1, 2)
+        .compose(FlowableTransformers.windowUntil(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v == -1;
+            }
+        }))
+        .flatMapSingle(toList)
+        .test()
+        .assertResult(
+                Arrays.asList(-1),
+                Arrays.asList(1, 2)
+        );
     }
 
     @SuppressWarnings("unchecked")
@@ -447,6 +484,25 @@ public class FlowableWindowPredicateTest {
         .assertValueCount(3)
         .requestMore(1)
         .assertValueCount(4);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void splitMatchBegin() {
+        Flowable.just(-1, 1, 2)
+        .compose(FlowableTransformers.windowSplit(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v == -1;
+            }
+        }))
+        .flatMapSingle(toList)
+        .test()
+        .assertResult(
+                Arrays.<Integer>asList(),
+                Arrays.asList(1, 2)
+        );
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/hu/akarnokd/rxjava2/operators/FlowableWindowPredicateTest.java
+++ b/src/test/java/hu/akarnokd/rxjava2/operators/FlowableWindowPredicateTest.java
@@ -114,6 +114,26 @@ public class FlowableWindowPredicateTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    public void whileNormalBackpressuredWindowEmitting() {
+        Flowable.just(1, 2, -1, 3, 4, 5, -1, -1, 6)
+        .compose(FlowableTransformers.windowWhile(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v != -1;
+            }
+        }))
+        .test(0)
+        .assertNoValues()
+        .requestMore(1)
+        .assertValueCount(1)
+        .requestMore(2)
+        .assertValueCount(3)
+        .requestMore(1)
+        .assertValueCount(4);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     public void untilNormal() {
         Flowable.just(1, 2, -1, 3, 4, 5, -1, -1, 6)
         .compose(FlowableTransformers.windowUntil(new Predicate<Integer>() {
@@ -182,6 +202,26 @@ public class FlowableWindowPredicateTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    public void untilNormalBackpressuredWindowEmitting() {
+        Flowable.just(1, 2, -1, 3, 4, 5, -1, -1, 6)
+        .compose(FlowableTransformers.windowUntil(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v == -1;
+            }
+        }))
+        .test(0)
+        .assertNoValues()
+        .requestMore(1)
+        .assertValueCount(1)
+        .requestMore(2)
+        .assertValueCount(3)
+        .requestMore(1)
+        .assertValueCount(4);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     public void emptyWhile() {
         Flowable.<Integer>empty()
         .compose(FlowableTransformers.windowWhile(new Predicate<Integer>() {
@@ -190,9 +230,8 @@ public class FlowableWindowPredicateTest {
                 return v != -1;
             }
         }))
-        .flatMapSingle(toList)
         .test()
-        .assertResult();
+        .assertNoValues();
     }
 
     @SuppressWarnings("unchecked")
@@ -205,9 +244,8 @@ public class FlowableWindowPredicateTest {
                 return v == -1;
             }
         }))
-        .flatMapSingle(toList)
         .test()
-        .assertResult();
+        .assertNoValues();
     }
 
     @SuppressWarnings("unchecked")
@@ -388,6 +426,26 @@ public class FlowableWindowPredicateTest {
                 Arrays.<Integer>asList(),
                 Arrays.asList(6)
         );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void splitNormalBackpressuredWindowEmitting() {
+        Flowable.just(1, 2, -1, 3, 4, 5, -1, -1, 6)
+        .compose(FlowableTransformers.windowSplit(new Predicate<Integer>() {
+            @Override
+            public boolean test(Integer v) throws Exception {
+                return v == -1;
+            }
+        }))
+        .test(0)
+        .assertNoValues()
+        .requestMore(1)
+        .assertValueCount(1)
+        .requestMore(2)
+        .assertValueCount(3)
+        .requestMore(1)
+        .assertValueCount(4);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
- fixup for #12
- must not eagerly emit a new window when the predicate triggers
- fixed by emitting the window on the next requested value (falling edge-trigger)
- for Mode.BEFORE it is necessary to save the current value until a
  new window gets requested (1 element look-ahead)
- backpressure tests didn't fully work as with `flatMapSingle(toList)` only
  values for completed inner windows where tested, test emitted counts instead

The level of complexity is quite a mouthful, despite having read your elaborated warning ;).
http://akarnokd.blogspot.de/2015/05/pitfalls-of-operator-implementations.html
http://akarnokd.blogspot.de/2015/05/pitfalls-of-operator-implementations_14.html