### PR TITLE
Add empty stacktrace to avoid misbehaviour on some JVMs

### DIFF
--- a/src/main/java/hu/akarnokd/rxjava2/debug/RxJavaAssemblyException.java
+++ b/src/main/java/hu/akarnokd/rxjava2/debug/RxJavaAssemblyException.java
@@ -103,6 +103,8 @@ public final class RxJavaAssemblyException extends RuntimeException {
     @Override
     public synchronized Throwable fillInStackTrace() {
         // don't store own stacktrace
+        // empty stacktrace prevents crashes on some JVMs when `getStackTrace()` is invoked
+        setStackTrace(new StackTraceElement[0]);
         return this;
     }
 


### PR DESCRIPTION
Just adding an empty stacktrace to RxJavaAssemblyException to make sure some `getStackTrace()` doesn't generate a NPE in some JVMs (misbehaving JVMs, I believe).

This PR the result of [an issue reported in my RxJava2Debug repo](https://github.com/akaita/RxJava2Debug/issues/2). 

In essence, Android clones the stacktrace every time `Throwable.getStacktrace()` is called. If the Throwable doesn't have a stacktrace, older versions of Android (6 and before) try to obtain the native stacktrace. The native stacktrace will be null, and `null.clone()` will blow up :) 

Although this PR is really fixing something that feels like Android's fault, Android is quite big on RxJava so I hope the change I propose is good enough to include it in the repo.

note: thanks so much for the repo!