### PR TITLE
Fix Github URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ sourceCompatibility = '1.6'
 targetCompatibility = '1.6'
 
 group = "com.github.akarnokd" 
-ext.githubProjectName = 'rxjava2-extensions'
+ext.githubProjectName = 'RxJava2Extensions'
 
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 


### PR DESCRIPTION
Github URLs in [POM](https://search.maven.org/artifact/com.github.akarnokd/rxjava2-extensions/0.20.3/jar) are currently incorrect, this PR should fix them.