### PR TITLE
Add support for conditionals in Single, Maybe and Completable

### DIFF
--- a/src/main/java/hu/akarnokd/rxjava2/expr/CompletableIfThen.java
+++ b/src/main/java/hu/akarnokd/rxjava2/expr/CompletableIfThen.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Completable;
+import io.reactivex.CompletableObserver;
+import io.reactivex.CompletableSource;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+/**
+ * When an Observer subscribes, the condition is evaluated and the appropriate
+ * CompletableSource is subscribed to.
+ */
+final class CompletableIfThen extends Completable {
+
+    final BooleanSupplier condition;
+
+    final CompletableSource then;
+
+    final CompletableSource orElse;
+
+    CompletableIfThen(BooleanSupplier condition, CompletableSource then,
+                      CompletableSource orElse) {
+        this.condition = condition;
+        this.then = then;
+        this.orElse = orElse;
+    }
+
+    @Override
+    protected void subscribeActual(CompletableObserver observer) {
+        boolean b;
+
+        try {
+            b = condition.getAsBoolean();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+
+        if (b) {
+            then.subscribe(observer);
+        } else {
+            orElse.subscribe(observer);
+        }
+    }
+}

--- a/src/main/java/hu/akarnokd/rxjava2/expr/CompletableSwitchCase.java
+++ b/src/main/java/hu/akarnokd/rxjava2/expr/CompletableSwitchCase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Completable;
+import io.reactivex.CompletableObserver;
+import io.reactivex.CompletableSource;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * For each Observer, it calls a keySelector for a key to lookup in the given Map for a CompletableSource
+ * to subscribe to; otherwise subscribe the Observer to the default CompletableSource.
+ *
+ * @param <K> the key type
+ */
+final class CompletableSwitchCase<K> extends Completable {
+
+    final Callable<? extends K> caseSelector;
+
+    final Map<? super K, ? extends CompletableSource> mapOfCases;
+
+    final CompletableSource defaultCase;
+
+    CompletableSwitchCase(Callable<? extends K> caseSelector,
+                          Map<? super K, ? extends CompletableSource> mapOfCases,
+                          CompletableSource defaultCase) {
+        this.caseSelector = caseSelector;
+        this.mapOfCases = mapOfCases;
+        this.defaultCase = defaultCase;
+    }
+
+    @Override
+    protected void subscribeActual(CompletableObserver observer) {
+        K key;
+        CompletableSource source;
+
+        try {
+            key = caseSelector.call();
+
+            source = mapOfCases.get(key);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+
+        if (source == null) {
+            source = defaultCase;
+        }
+
+        source.subscribe(observer);
+    }
+}

--- a/src/main/java/hu/akarnokd/rxjava2/expr/MaybeIfThen.java
+++ b/src/main/java/hu/akarnokd/rxjava2/expr/MaybeIfThen.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.MaybeSource;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+/**
+ * When an Observer subscribes, the condition is evaluated and the appropriate
+ * MaybeSource is subscribed to.
+ *
+ * @param <T> the common value type of the Maybes
+ */
+final class MaybeIfThen<T> extends Maybe<T> {
+
+    final BooleanSupplier condition;
+
+    final MaybeSource<? extends T> then;
+
+    final MaybeSource<? extends T> orElse;
+
+    MaybeIfThen(BooleanSupplier condition, MaybeSource<? extends T> then,
+                 MaybeSource<? extends T> orElse) {
+        this.condition = condition;
+        this.then = then;
+        this.orElse = orElse;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        boolean b;
+
+        try {
+            b = condition.getAsBoolean();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+
+        if (b) {
+            then.subscribe(observer);
+        } else {
+            orElse.subscribe(observer);
+        }
+    }
+}

--- a/src/main/java/hu/akarnokd/rxjava2/expr/MaybeSwitchCase.java
+++ b/src/main/java/hu/akarnokd/rxjava2/expr/MaybeSwitchCase.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Maybe;
+import io.reactivex.MaybeObserver;
+import io.reactivex.MaybeSource;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * For each Observer, it calls a keySelector for a key to lookup in the given Map for a MaybeSource
+ * to subscribe to; otherwise subscribe the Observer to the default MaybeSource.
+ *
+ * @param <T> the output value type
+ * @param <K> the key type
+ */
+final class MaybeSwitchCase<T, K> extends Maybe<T> {
+
+    final Callable<? extends K> caseSelector;
+
+    final Map<? super K, ? extends MaybeSource<? extends T>> mapOfCases;
+
+    final MaybeSource<? extends T> defaultCase;
+
+    MaybeSwitchCase(Callable<? extends K> caseSelector,
+                     Map<? super K, ? extends MaybeSource<? extends T>> mapOfCases,
+                     MaybeSource<? extends T> defaultCase) {
+        this.caseSelector = caseSelector;
+        this.mapOfCases = mapOfCases;
+        this.defaultCase = defaultCase;
+    }
+
+    @Override
+    protected void subscribeActual(MaybeObserver<? super T> observer) {
+        K key;
+        MaybeSource<? extends T> source;
+
+        try {
+            key = caseSelector.call();
+
+            source = mapOfCases.get(key);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+
+        if (source == null) {
+            source = defaultCase;
+        }
+
+        source.subscribe(observer);
+    }
+}

--- a/src/main/java/hu/akarnokd/rxjava2/expr/SingleIfThen.java
+++ b/src/main/java/hu/akarnokd/rxjava2/expr/SingleIfThen.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.SingleSource;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+/**
+ * When an Observer subscribes, the condition is evaluated and the appropriate
+ * SingleSource is subscribed to.
+ *
+ * @param <T> the common value type of the Singles
+ */
+final class SingleIfThen<T> extends Single<T> {
+
+    final BooleanSupplier condition;
+
+    final SingleSource<? extends T> then;
+
+    final SingleSource<? extends T> orElse;
+
+    SingleIfThen(BooleanSupplier condition, SingleSource<? extends T> then,
+                 SingleSource<? extends T> orElse) {
+        this.condition = condition;
+        this.then = then;
+        this.orElse = orElse;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        boolean b;
+
+        try {
+            b = condition.getAsBoolean();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+
+        if (b) {
+            then.subscribe(observer);
+        } else {
+            orElse.subscribe(observer);
+        }
+    }
+}

--- a/src/main/java/hu/akarnokd/rxjava2/expr/SingleSwitchCase.java
+++ b/src/main/java/hu/akarnokd/rxjava2/expr/SingleSwitchCase.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+import io.reactivex.SingleSource;
+import io.reactivex.exceptions.Exceptions;
+import io.reactivex.internal.disposables.EmptyDisposable;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * For each Observer, it calls a keySelector for a key to lookup in the given Map for a SingleSource
+ * to subscribe to; otherwise subscribe the Observer to the default SingleSource.
+ *
+ * @param <T> the output value type
+ * @param <K> the key type
+ */
+final class SingleSwitchCase<T, K> extends Single<T> {
+
+    final Callable<? extends K> caseSelector;
+
+    final Map<? super K, ? extends SingleSource<? extends T>> mapOfCases;
+
+    final SingleSource<? extends T> defaultCase;
+
+    SingleSwitchCase(Callable<? extends K> caseSelector,
+                     Map<? super K, ? extends SingleSource<? extends T>> mapOfCases,
+                     SingleSource<? extends T> defaultCase) {
+        this.caseSelector = caseSelector;
+        this.mapOfCases = mapOfCases;
+        this.defaultCase = defaultCase;
+    }
+
+    @Override
+    protected void subscribeActual(SingleObserver<? super T> observer) {
+        K key;
+        SingleSource<? extends T> source;
+
+        try {
+            key = caseSelector.call();
+
+            source = mapOfCases.get(key);
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            EmptyDisposable.error(ex, observer);
+            return;
+        }
+
+        if (source == null) {
+            source = defaultCase;
+        }
+
+        source.subscribe(observer);
+    }
+}

--- a/src/main/java/hu/akarnokd/rxjava2/expr/StatementCompletable.java
+++ b/src/main/java/hu/akarnokd/rxjava2/expr/StatementCompletable.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Completable;
+import io.reactivex.CompletableSource;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * Imperative statements expressed as Completable operators.
+ */
+public final class StatementCompletable {
+
+    /**
+     * Return a particular one of several possible Completables based on a case
+     * selector, or a default Completable if the case selector does not map to
+     * a particular one.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchCase.png" alt="">
+     *
+     * @param <K>
+     *            the case key type
+     * @param <R>
+     *            the result value type
+     * @param caseSelector
+     *            the function that produces a case key when an
+     *            CompletableObserver subscribes
+     * @param mapOfCases
+     *            a map that maps a case key to a Completable
+     * @param defaultCase
+     *            the default Completable if the {@code mapOfCases} doesn't contain a value for the key returned by the {@code caseSelector}
+     * @return a particular Completable chosen by key from the map of
+     *         Completables, or the default case if no Completable matches the key
+     */
+    public static <K> Completable switchCase(Callable<? extends K> caseSelector,
+            Map<? super K, ? extends CompletableSource> mapOfCases,
+                    CompletableSource defaultCase) {
+        ObjectHelper.requireNonNull(caseSelector, "caseSelector is null");
+        ObjectHelper.requireNonNull(mapOfCases, "mapOfCases is null");
+        ObjectHelper.requireNonNull(defaultCase, "defaultCase is null");
+        return RxJavaPlugins.onAssembly(new CompletableSwitchCase<K>(caseSelector, mapOfCases, defaultCase));
+    }
+
+    /**
+     * Return a Completable that emits the emissions from one specified
+     * Completable if a condition evaluates to true, or from another specified
+     * Completable otherwise.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/ifThen.e.png" alt="">
+     *
+     * @param <R>
+     *            the result value type
+     * @param condition
+     *            the condition that decides which Completable to emit the
+     *            emissions from
+     * @param then
+     *            the Completable sequence to emit to if {@code condition} is {@code true}
+     * @param orElse
+     *            the Completable sequence to emit to if {@code condition} is {@code false}
+     * @return a Completable that mimics either the {@code then} or {@code orElse} Completables depending on a condition function
+     */
+    public static Completable ifThen(BooleanSupplier condition, CompletableSource then,
+            Completable orElse) {
+        ObjectHelper.requireNonNull(condition, "condition is null");
+        ObjectHelper.requireNonNull(then, "then is null");
+        ObjectHelper.requireNonNull(orElse, "orElse is null");
+        return RxJavaPlugins.onAssembly(new CompletableIfThen(condition, then, orElse));
+    }
+}

--- a/src/main/java/hu/akarnokd/rxjava2/expr/StatementMaybe.java
+++ b/src/main/java/hu/akarnokd/rxjava2/expr/StatementMaybe.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Maybe;
+import io.reactivex.MaybeSource;
+import io.reactivex.Scheduler;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * Imperative statements expressed as Maybe operators.
+ */
+public final class StatementMaybe {
+
+    /** Factory class. */
+    private StatementMaybe() { throw new IllegalStateException("No instances!"); }
+    /**
+     * Return a particular one of several possible Maybes based on a case
+     * selector.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchCase.png" alt="">
+     *
+     * @param <K>
+     *            the case key type
+     * @param <R>
+     *            the result value type
+     * @param caseSelector
+     *            the function that produces a case key when an
+     *            MaybeObserver subscribes
+     * @param mapOfCases
+     *            a map that maps a case key to a Maybe
+     * @return a particular Maybe chosen by key from the map of
+     *         Maybes, or an empty Maybe if no Maybe matches the
+     *         key
+     */
+    public static <K, R> Maybe<R> switchCase(Callable<? extends K> caseSelector,
+            Map<? super K, ? extends MaybeSource<? extends R>> mapOfCases) {
+        return switchCase(caseSelector, mapOfCases, Maybe.<R> empty());
+    }
+
+    /**
+     * Return a particular one of several possible Maybes based on a case
+     * selector and run it on the designated scheduler.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchCase.s.png" alt="">
+     *
+     * @param <K>
+     *            the case key type
+     * @param <R>
+     *            the result value type
+     * @param caseSelector
+     *            the function that produces a case key when an
+     *            MaybeObserver subscribes
+     * @param mapOfCases
+     *            a map that maps a case key to a Maybe
+     * @param scheduler
+     *            the scheduler where the empty maybe is observed
+     * @return a particular Maybe chosen by key from the map of
+     *         Maybes, or an empty Maybe if no Maybe matches the
+     *         key, but one that runs on the designated scheduler in either case
+     */
+    public static <K, R> Maybe<R> switchCase(Callable<? extends K> caseSelector,
+            Map<? super K, ? extends MaybeSource<? extends R>> mapOfCases, Scheduler scheduler) {
+        return switchCase(caseSelector, mapOfCases, Maybe.<R> empty().subscribeOn(scheduler));
+    }
+
+    /**
+     * Return a particular one of several possible Maybes based on a case
+     * selector, or a default Maybe if the case selector does not map to
+     * a particular one.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchCase.png" alt="">
+     *
+     * @param <K>
+     *            the case key type
+     * @param <R>
+     *            the result value type
+     * @param caseSelector
+     *            the function that produces a case key when an
+     *            MaybeObserver subscribes
+     * @param mapOfCases
+     *            a map that maps a case key to a Maybe
+     * @param defaultCase
+     *            the default Maybe if the {@code mapOfCases} doesn't contain a value for the key returned by the {@code caseSelector}
+     * @return a particular Maybe chosen by key from the map of
+     *         Maybes, or the default case if no Maybe matches the key
+     */
+    public static <K, R> Maybe<R> switchCase(Callable<? extends K> caseSelector,
+            Map<? super K, ? extends MaybeSource<? extends R>> mapOfCases,
+                    MaybeSource<? extends R> defaultCase) {
+        ObjectHelper.requireNonNull(caseSelector, "caseSelector is null");
+        ObjectHelper.requireNonNull(mapOfCases, "mapOfCases is null");
+        ObjectHelper.requireNonNull(defaultCase, "defaultCase is null");
+        return RxJavaPlugins.onAssembly(new MaybeSwitchCase<R, K>(caseSelector, mapOfCases, defaultCase));
+    }
+
+    /**
+     * Return a Maybe that emits the emissions from a specified Maybe
+     * if a condition evaluates to true, otherwise return an empty Maybe.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/ifThen.png" alt="">
+     *
+     * @param <R>
+     *            the result value type
+     * @param condition
+     *            the condition that decides whether to emit the emissions
+     *            from the <code>then</code> Maybe
+     * @param then
+     *            the Maybe sequence to emit to if {@code condition} is {@code true}
+     * @return a Maybe that mimics the {@code then} Maybe if the {@code condition} function evaluates to true, or an empty
+     *         Maybe otherwise
+     */
+    public static <R> Maybe<R> ifThen(BooleanSupplier condition, MaybeSource<? extends R> then) {
+        return ifThen(condition, then, Maybe.<R> empty());
+    }
+
+    /**
+     * Return a Maybe that emits the emissions from a specified Maybe
+     * if a condition evaluates to true, otherwise return an empty Maybe
+     * that runs on a specified Scheduler.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/ifThen.s.png" alt="">
+     *
+     * @param <R>
+     *            the result value type
+     * @param condition
+     *            the condition that decides whether to emit the emissions
+     *            from the <code>then</code> Maybe
+     * @param then
+     *            the Maybe sequence to emit to if {@code condition} is {@code true}
+     * @param scheduler
+     *            the Scheduler on which the empty Maybe runs if the
+     *            in case the condition returns false
+     * @return a Maybe that mimics the {@code then} Maybe if the {@code condition} function evaluates to true, or an empty
+     *         Maybe running on the specified Scheduler otherwise
+     */
+    public static <R> Maybe<R> ifThen(BooleanSupplier condition, MaybeSource<? extends R> then, Scheduler scheduler) {
+        return ifThen(condition, then, Maybe.<R> empty().subscribeOn(scheduler));
+    }
+
+    /**
+     * Return a Maybe that emits the emissions from one specified
+     * Maybe if a condition evaluates to true, or from another specified
+     * Maybe otherwise.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/ifThen.e.png" alt="">
+     *
+     * @param <R>
+     *            the result value type
+     * @param condition
+     *            the condition that decides which Maybe to emit the
+     *            emissions from
+     * @param then
+     *            the Maybe sequence to emit to if {@code condition} is {@code true}
+     * @param orElse
+     *            the Maybe sequence to emit to if {@code condition} is {@code false}
+     * @return a Maybe that mimics either the {@code then} or {@code orElse} Maybes depending on a condition function
+     */
+    public static <R> Maybe<R> ifThen(BooleanSupplier condition, MaybeSource<? extends R> then,
+            Maybe<? extends R> orElse) {
+        ObjectHelper.requireNonNull(condition, "condition is null");
+        ObjectHelper.requireNonNull(then, "then is null");
+        ObjectHelper.requireNonNull(orElse, "orElse is null");
+        return RxJavaPlugins.onAssembly(new MaybeIfThen<R>(condition, then, orElse));
+    }
+}

--- a/src/main/java/hu/akarnokd/rxjava2/expr/StatementSingle.java
+++ b/src/main/java/hu/akarnokd/rxjava2/expr/StatementSingle.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Single;
+import io.reactivex.SingleSource;
+import io.reactivex.Scheduler;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.internal.functions.ObjectHelper;
+import io.reactivex.plugins.RxJavaPlugins;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * Imperative statements expressed as Single operators.
+ */
+public final class StatementSingle {
+
+    /**
+     * Return a particular one of several possible Singles based on a case
+     * selector, or a default Single if the case selector does not map to
+     * a particular one.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchCase.png" alt="">
+     *
+     * @param <K>
+     *            the case key type
+     * @param <R>
+     *            the result value type
+     * @param caseSelector
+     *            the function that produces a case key when an
+     *            SingleObserver subscribes
+     * @param mapOfCases
+     *            a map that maps a case key to a Single
+     * @param defaultCase
+     *            the default Single if the {@code mapOfCases} doesn't contain a value for the key returned by the {@code caseSelector}
+     * @return a particular Single chosen by key from the map of
+     *         Singles, or the default case if no Single matches the key
+     */
+    public static <K, R> Single<R> switchCase(Callable<? extends K> caseSelector,
+            Map<? super K, ? extends SingleSource<? extends R>> mapOfCases,
+                    SingleSource<? extends R> defaultCase) {
+        ObjectHelper.requireNonNull(caseSelector, "caseSelector is null");
+        ObjectHelper.requireNonNull(mapOfCases, "mapOfCases is null");
+        ObjectHelper.requireNonNull(defaultCase, "defaultCase is null");
+        return RxJavaPlugins.onAssembly(new SingleSwitchCase<R, K>(caseSelector, mapOfCases, defaultCase));
+    }
+
+    /**
+     * Return a Single that emits the emissions from one specified
+     * Single if a condition evaluates to true, or from another specified
+     * Single otherwise.
+     * <p>
+     * <img width="640" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/ifThen.e.png" alt="">
+     *
+     * @param <R>
+     *            the result value type
+     * @param condition
+     *            the condition that decides which Single to emit the
+     *            emissions from
+     * @param then
+     *            the Single sequence to emit to if {@code condition} is {@code true}
+     * @param orElse
+     *            the Single sequence to emit to if {@code condition} is {@code false}
+     * @return a Single that mimics either the {@code then} or {@code orElse} Singles depending on a condition function
+     */
+    public static <R> Single<R> ifThen(BooleanSupplier condition, SingleSource<? extends R> then,
+            Single<? extends R> orElse) {
+        ObjectHelper.requireNonNull(condition, "condition is null");
+        ObjectHelper.requireNonNull(then, "then is null");
+        ObjectHelper.requireNonNull(orElse, "orElse is null");
+        return RxJavaPlugins.onAssembly(new SingleIfThen<R>(condition, then, orElse));
+    }
+}

--- a/src/test/java/hu/akarnokd/rxjava2/expr/StatementCompletableTest.java
+++ b/src/test/java/hu/akarnokd/rxjava2/expr/StatementCompletableTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Completable;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.schedulers.TestScheduler;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class StatementCompletableTest {
+    TestScheduler scheduler;
+    Callable func;
+    Callable funcError;
+    BooleanSupplier condition;
+    BooleanSupplier conditionError;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+        scheduler = new TestScheduler();
+        func = new Callable() {
+            int count = 1;
+
+            @Override
+            public Integer call() {
+                return count++;
+            }
+        };
+        funcError = new Callable() {
+            int count = 1;
+
+            @Override
+            public Integer call() {
+                if (count == 2) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return count++;
+            }
+        };
+        condition = new BooleanSupplier() {
+            boolean r;
+
+            @Override
+            public boolean getAsBoolean() {
+                r = !r;
+                return r;
+            }
+
+        };
+        conditionError = new BooleanSupplier() {
+            boolean r;
+
+            @Override
+            public boolean getAsBoolean() {
+                r = !r;
+                if (!r) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return r;
+            }
+
+        };
+    }
+
+     void observe(Completable source) {
+        source.test().assertComplete();
+    }
+
+     void observeError(Completable source, Class<? extends Throwable> error) {
+        source.test().assertFailure(error);
+    }
+
+    @Test
+    public void testSimple() {
+        Completable source1 = Completable.complete();
+        Completable source2 = Completable.complete();
+        Completable defaultSource = Completable.error(new RuntimeException("Forced Failure"));
+
+        Map<Integer, Completable> map = new HashMap<Integer, Completable>();
+        map.put(1, source1);
+        map.put(2, source2);
+
+        Completable result = StatementCompletable.switchCase(func, map, defaultSource);
+
+        observe(result);
+        observe(result);
+    }
+
+    @Test
+    public void testDefaultCase() {
+        Completable source1 = Completable.error(new RuntimeException("Forced Failure"));
+        Completable source2 = Completable.complete();
+
+        Map<Integer, Completable> map = new HashMap<Integer, Completable>();
+        map.put(1, source1);
+
+        Completable result = StatementCompletable.switchCase(func, map, source2);
+
+        observeError(result, RuntimeException.class);
+        observe(result);
+    }
+
+    @Test
+    public void testCaseSelectorThrows() {
+        Completable source1 = Completable.complete();
+        Completable defaultSource = Completable.complete();
+
+        Map<Integer, Completable> map = new HashMap<Integer, Completable>();
+        map.put(1, source1);
+
+        Completable result = StatementCompletable.switchCase(funcError, map, defaultSource);
+
+        observe(result);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testMapGetThrows() {
+        Completable source1 = Completable.complete();
+        Completable source2 = Completable.complete();
+        Completable defaultSource = Completable.complete();
+
+        Map<Integer, Completable> map = new HashMap<Integer, Completable>() {
+            private static final long serialVersionUID = -4342868139960216388L;
+
+            @Override
+            public Completable get(Object key) {
+                if (key.equals(2)) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return super.get(key);
+            }
+
+        };
+        map.put(1, source1);
+        map.put(2, source2);
+
+        Completable result = StatementCompletable.switchCase(func, map, defaultSource);
+
+        observe(result);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testMapContainsKeyThrows() {
+        Completable source1 = Completable.complete();
+        Completable defaultSource = Completable.complete();
+
+        Map<Integer, Completable> map = new HashMap<Integer, Completable>() {
+            private static final long serialVersionUID = 1975411728567003983L;
+
+            @Override
+            public Completable get(Object key) {
+                if (key.equals(2)) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return super.get(key);
+            }
+
+        };
+        map.put(1, source1);
+
+        Completable result = StatementCompletable.switchCase(func, map, defaultSource);
+
+        observe(result);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testChosenCompletableThrows() {
+        Completable source1 = Completable.complete();
+        Completable source2 = Completable.error(new RuntimeException("Forced failure"));
+        Completable defaultSource = Completable.complete();
+
+        Map<Integer, Completable> map = new HashMap<Integer, Completable>();
+        map.put(1, source1);
+        map.put(2, source2);
+
+        Completable result = StatementCompletable.switchCase(func, map, defaultSource);
+
+        observe(result);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testIfThenElse() {
+        Completable source1 = Completable.complete();
+        Completable source2 = Completable.error(new RuntimeException("Forced failure"));
+
+        Completable result = StatementCompletable.ifThen(condition, source1, source2);
+
+        observe(result);
+        observeError(result, RuntimeException.class);
+        observe(result);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testIfThenConditionThrows() {
+        Completable source1 = Completable.complete();
+        Completable source2 = Completable.complete();
+
+        Completable result = StatementCompletable.ifThen(conditionError, source1, source2);
+
+        observe(result);
+        observeError(result, RuntimeException.class);
+        observe(result);
+        observeError(result, RuntimeException.class);
+    }
+}

--- a/src/test/java/hu/akarnokd/rxjava2/expr/StatementMaybeTest.java
+++ b/src/test/java/hu/akarnokd/rxjava2/expr/StatementMaybeTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Maybe;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.schedulers.TestScheduler;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class StatementMaybeTest {
+    TestScheduler scheduler;
+    Callable<Integer> func;
+    Callable<Integer> funcError;
+    BooleanSupplier condition;
+    BooleanSupplier conditionError;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+        scheduler = new TestScheduler();
+        func = new Callable<Integer>() {
+            int count = 1;
+
+            @Override
+            public Integer call() {
+                return count++;
+            }
+        };
+        funcError = new Callable<Integer>() {
+            int count = 1;
+
+            @Override
+            public Integer call() {
+                if (count == 2) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return count++;
+            }
+        };
+        condition = new BooleanSupplier() {
+            boolean r;
+
+            @Override
+            public boolean getAsBoolean() {
+                r = !r;
+                return r;
+            }
+
+        };
+        conditionError = new BooleanSupplier() {
+            boolean r;
+
+            @Override
+            public boolean getAsBoolean() {
+                r = !r;
+                if (!r) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return r;
+            }
+
+        };
+    }
+
+    <T> void observe(Maybe<T> source) {
+        source.test().assertNoValues().assertNoErrors();
+    }
+
+    <T> void observe(Maybe<T> source, T value) {
+        source.test().assertResult(value);
+    }
+
+    <T> void observeError(Maybe<T> source, Class<? extends Throwable> error) {
+        source.test().assertFailure(error);
+    }
+
+    @Test
+    public void testSimple() {
+        Maybe<Integer> source1 = Maybe.just(1);
+        Maybe<Integer> source2 = Maybe.just(2);
+
+        Map<Integer, Maybe<Integer>> map = new HashMap<Integer, Maybe<Integer>>();
+        map.put(1, source1);
+        map.put(2, source2);
+
+        Maybe<Integer> result = StatementMaybe.switchCase(func, map);
+
+        observe(result, 1);
+        observe(result, 2);
+        observe(result);
+    }
+
+    @Test
+    public void testDefaultCase() {
+        Maybe<Integer> source1 = Maybe.just(1);
+        Maybe<Integer> defaultSource = Maybe.just(2);
+
+        Map<Integer, Maybe<Integer>> map = new HashMap<Integer, Maybe<Integer>>();
+        map.put(1, source1);
+
+        Maybe<Integer> result = StatementMaybe.switchCase(func, map, defaultSource);
+
+        observe(result, 1);
+        observe(result, 2);
+        observe(result, 2);
+    }
+
+    @Test
+    public void testCaseSelectorThrows() {
+        Maybe<Integer> source1 = Maybe.just(1);
+
+        Map<Integer, Maybe<Integer>> map = new HashMap<Integer, Maybe<Integer>>();
+        map.put(1, source1);
+
+        Maybe<Integer> result = StatementMaybe.switchCase(funcError, map);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testMapGetThrows() {
+        Maybe<Integer> source1 = Maybe.just(1);
+        Maybe<Integer> source2 = Maybe.just(2);
+
+        Map<Integer, Maybe<Integer>> map = new HashMap<Integer, Maybe<Integer>>() {
+            private static final long serialVersionUID = -4342868139960216388L;
+
+            @Override
+            public Maybe<Integer> get(Object key) {
+                if (key.equals(2)) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return super.get(key);
+            }
+
+        };
+        map.put(1, source1);
+        map.put(2, source2);
+
+        Maybe<Integer> result = StatementMaybe.switchCase(func, map);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testMapContainsKeyThrows() {
+        Maybe<Integer> source1 = Maybe.just(1);
+
+        Map<Integer, Maybe<Integer>> map = new HashMap<Integer, Maybe<Integer>>() {
+            private static final long serialVersionUID = 1975411728567003983L;
+
+            @Override
+            public Maybe<Integer> get(Object key) {
+                if (key.equals(2)) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return super.get(key);
+            }
+
+        };
+        map.put(1, source1);
+
+        Maybe<Integer> result = StatementMaybe.switchCase(func, map);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testChosenMaybeThrows() {
+        Maybe<Integer> source1 = Maybe.just(1);
+        Maybe<Integer> source2 = Maybe.error(new RuntimeException("Forced failure"));
+
+        Map<Integer, Maybe<Integer>> map = new HashMap<Integer, Maybe<Integer>>();
+        map.put(1, source1);
+        map.put(2, source2);
+
+        Maybe<Integer> result = StatementMaybe.switchCase(func, map);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testIfThen() {
+        Maybe<Integer> source1 = Maybe.just(1);
+
+        Maybe<Integer> result = StatementMaybe.ifThen(condition, source1);
+
+        observe(result, 1);
+        observe(result);
+        observe(result, 1);
+        observe(result);
+    }
+
+    @Test
+    public void testIfThenElse() {
+        Maybe<Integer> source1 = Maybe.just(1);
+        Maybe<Integer> source2 = Maybe.just(2);
+
+        Maybe<Integer> result = StatementMaybe.ifThen(condition, source1, source2);
+
+        observe(result, 1);
+        observe(result, 2);
+        observe(result, 1);
+        observe(result, 2);
+    }
+
+    @Test
+    public void testIfThenConditonThrows() {
+        Maybe<Integer> source1 = Maybe.just(1);
+
+        Maybe<Integer> result = StatementMaybe.ifThen(conditionError, source1);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testIfThenMaybeThrows() {
+        Maybe<Integer> source1 = Maybe.error(new RuntimeException("Forced failure!"));
+
+        Maybe<Integer> result = StatementMaybe.ifThen(condition, source1);
+
+        observeError(result, RuntimeException.class);
+        observe(result);
+
+        observeError(result, RuntimeException.class);
+        observe(result);
+    }
+
+    @Test
+    public void testIfThenElseMaybeThrows() {
+        Maybe<Integer> source1 = Maybe.just(1);
+        Maybe<Integer> source2 = Maybe.error(new RuntimeException("Forced failure!"));
+
+        Maybe<Integer> result = StatementMaybe.ifThen(condition, source1, source2);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+}

--- a/src/test/java/hu/akarnokd/rxjava2/expr/StatementSingleTest.java
+++ b/src/test/java/hu/akarnokd/rxjava2/expr/StatementSingleTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2016-2018 David Karnok
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hu.akarnokd.rxjava2.expr;
+
+import io.reactivex.Single;
+import io.reactivex.SingleSource;
+import io.reactivex.functions.BooleanSupplier;
+import io.reactivex.schedulers.TestScheduler;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+public class StatementSingleTest {
+    TestScheduler scheduler;
+    Callable<Integer> func;
+    Callable<Integer> funcError;
+    BooleanSupplier condition;
+    BooleanSupplier conditionError;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+        scheduler = new TestScheduler();
+        func = new Callable<Integer>() {
+            int count = 1;
+
+            @Override
+            public Integer call() {
+                return count++;
+            }
+        };
+        funcError = new Callable<Integer>() {
+            int count = 1;
+
+            @Override
+            public Integer call() {
+                if (count == 2) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return count++;
+            }
+        };
+        condition = new BooleanSupplier() {
+            boolean r;
+
+            @Override
+            public boolean getAsBoolean() {
+                r = !r;
+                return r;
+            }
+
+        };
+        conditionError = new BooleanSupplier() {
+            boolean r;
+
+            @Override
+            public boolean getAsBoolean() {
+                r = !r;
+                if (!r) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return r;
+            }
+
+        };
+    }
+
+    <T> void observe(Single<T> source, T value) {
+        source.test().assertResult(value);
+    }
+
+    <T> void observeError(Single<T> source, Class<? extends Throwable> error) {
+        source.test().assertFailure(error);
+    }
+
+    @Test
+    public void testSimple() {
+        Single<Integer> source1 = Single.just(1);
+        Single<Integer> source2 = Single.just(2);
+        Single<Integer> defaultSource = Single.just(Integer.MAX_VALUE);
+
+        Map<Integer, Single<Integer>> map = new HashMap<Integer, Single<Integer>>();
+        map.put(1, source1);
+        map.put(2, source2);
+
+        Single<Integer> result = StatementSingle.switchCase(func, map, defaultSource);
+
+        observe(result, 1);
+        observe(result, 2);
+    }
+
+    @Test
+    public void testDefaultCase() {
+        Single<Integer> source1 = Single.just(1);
+        Single<Integer> source2 = Single.just(2);
+
+        Map<Integer, Single<Integer>> map = new HashMap<Integer, Single<Integer>>();
+        map.put(1, source1);
+
+        Single<Integer> result = StatementSingle.switchCase(func, map, source2);
+
+        observe(result, 1);
+        observe(result, 2);
+        observe(result, 2);
+    }
+
+    @Test
+    public void testCaseSelectorThrows() {
+        Single<Integer> source1 = Single.just(1);
+        Single<Integer> defaultSource = Single.just(Integer.MAX_VALUE);
+
+        Map<Integer, Single<Integer>> map = new HashMap<Integer, Single<Integer>>();
+        map.put(1, source1);
+
+        Single<Integer> result = StatementSingle.switchCase(funcError, map, defaultSource);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testMapGetThrows() {
+        Single<Integer> source1 = Single.just(1);
+        Single<Integer> source2 = Single.just(2);
+        Single<Integer> defaultSource = Single.just(Integer.MAX_VALUE);
+
+        Map<Integer, Single<Integer>> map = new HashMap<Integer, Single<Integer>>() {
+            private static final long serialVersionUID = -4342868139960216388L;
+
+            @Override
+            public Single<Integer> get(Object key) {
+                if (key.equals(2)) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return super.get(key);
+            }
+
+        };
+        map.put(1, source1);
+        map.put(2, source2);
+
+        Single<Integer> result = StatementSingle.switchCase(func, map, defaultSource);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testMapContainsKeyThrows() {
+        Single<Integer> source1 = Single.just(1);
+        Single<Integer> defaultSource = Single.just(Integer.MAX_VALUE);
+
+        Map<Integer, Single<Integer>> map = new HashMap<Integer, Single<Integer>>() {
+            private static final long serialVersionUID = 1975411728567003983L;
+
+            @Override
+            public Single<Integer> get(Object key) {
+                if (key.equals(2)) {
+                    throw new RuntimeException("Forced failure!");
+                }
+                return super.get(key);
+            }
+
+        };
+        map.put(1, source1);
+
+        Single<Integer> result = StatementSingle.switchCase(func, map, defaultSource);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testChosenSingleThrows() {
+        Single<Integer> source1 = Single.just(1);
+        Single<Integer> source2 = Single.error(new RuntimeException("Forced failure"));
+        Single<Integer> defaultSource = Single.just(Integer.MAX_VALUE);
+
+        Map<Integer, Single<Integer>> map = new HashMap<Integer, Single<Integer>>();
+        map.put(1, source1);
+        map.put(2, source2);
+
+        Single<Integer> result = StatementSingle.switchCase(func, map, defaultSource);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testIfThenElse() {
+        Single<Integer> source1 = Single.just(1);
+        Single<Integer> source2 = Single.just(2);
+
+        Single<Integer> result = StatementSingle.ifThen(condition, source1, source2);
+
+        observe(result, 1);
+        observe(result, 2);
+        observe(result, 1);
+        observe(result, 2);
+    }
+
+    @Test
+    public void testIfThenConditionThrows() {
+        Single<Integer> source1 = Single.just(1);
+        Single<Integer> source2 = Single.just(2);
+
+        Single<Integer> result = StatementSingle.ifThen(conditionError, source1, source2);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+
+    @Test
+    public void testIfThenElseSingleThrows() {
+        Single<Integer> source1 = Single.just(1);
+        Single<Integer> source2 = Single.error(new RuntimeException("Forced failure!"));
+
+        Single<Integer> result = StatementSingle.ifThen(condition, source1, source2);
+
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+        observe(result, 1);
+        observeError(result, RuntimeException.class);
+    }
+}


### PR DESCRIPTION
Adds support for the `ifThen` and `switch` conditional statements for `Single`, `Maybe`, and `Completable` types.

This work is based mostly on the `ObservableStatement`, `ObservableIfThen`, and `ObservableSwitch` classes and the tests were derived from `ObservableStatementTest`

The `doWhile` and `whileDo` functionality in the `Observable` operations were not moved across as they make sense only in the context of multiple value emissions and the operations added have at most 1 value emission.

The `Maybe` operations continue the pattern of using an `empty` value as default return value in the `switch` method and as the default `else` condition in the `ifThen` method.

The `Single` operation force a mandatory default value as there is no `empty` equivalent for `Single`. An alternative could be to return a `Single.error(new RuntimeException("no default value provided")` but I feel that this is not obvious behaviour and could therefore confuse clients consuming the method.

The `CompletableStatementTest` test cases have had to rely considerable more on `Completable.error(new RuntimeException("Forced Failure"))` to ensure that the correct subscriptions are made since there are no values on which to compare.