### PR TITLE
RxJavaAssemblyException prints StackTrace in getMessage

### DIFF
--- a/src/main/java/hu/akarnokd/rxjava3/debug/RxJavaAssemblyException.java
+++ b/src/main/java/hu/akarnokd/rxjava3/debug/RxJavaAssemblyException.java
@@ -36,11 +36,13 @@ public final class RxJavaAssemblyException extends RuntimeException {
 
         StackTraceElement[] es = Thread.currentThread().getStackTrace();
 
-        b.append("RxJavaAssemblyException: assembled\r\n");
+        b.append("RxJavaAssemblyException: assembled");
 
         for (StackTraceElement e : es) {
             if (filter(e)) {
-                b.append("at ").append(e).append("\r\n");
+                b.append(System.lineSeparator())
+                 .append("\tat ")
+                 .append(e);
             }
         }
 
@@ -154,5 +156,10 @@ public final class RxJavaAssemblyException extends RuntimeException {
             }
         }
         return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return stacktrace;
     }
 }


### PR DESCRIPTION
Tested in Eclipse ad IntelliJ:
![rx-error-eclipse](https://user-images.githubusercontent.com/10479845/90535090-ce341180-e17a-11ea-95de-688e503ac300.png)
![rx-error-intellij](https://user-images.githubusercontent.com/10479845/90535103-d12f0200-e17a-11ea-993a-ad675de4ba1d.png)


Proposition for #76 